### PR TITLE
Support for Appveyor builds

### DIFF
--- a/ClassicShellSrc/BUILDME.txt
+++ b/ClassicShellSrc/BUILDME.txt
@@ -11,7 +11,7 @@ Visual Studio 2017 (Community Edition is enough)
   - Visual C++ ATL support
 HTML Help Workshop
 WiX 3.7
-WinRAR
+7-Zip
 It is possible to convert the projects to newer versions of Visual Studio and newer SDKs.
 Newer versions of WiX will probably work fine.
 

--- a/ClassicShellSrc/ClassicShellSetup/BuildArchives.bat
+++ b/ClassicShellSrc/ClassicShellSetup/BuildArchives.bat
@@ -1,18 +1,22 @@
 REM ***** Collect PDBs
 
 del Final\ClassicShellPDB_%CS_VERSION_STR%.zip
-"C:\Program Files\WinRAR\winrar" a -afzip -ep1 Final\ClassicShellPDB_%CS_VERSION_STR%.zip Output\PDB32 Output\PDB64
+cd Output
+7z a ..\Final\ClassicShellPDB_%CS_VERSION_STR%.zip PDB32 PDB64
+cd ..
 
 cd ..
 
 REM ***** Collect Sources
 
 del ClassicShellSetup\Final\ClassicShellSrc_%CS_VERSION_STR%.zip
-"C:\Program Files\WinRAR\winrar" a -afzip -ep1 -ed -r -x*.intermediate.manifest -x*.embed.manifest -x*_i.h -xWebsite\ ClassicShellSetup\Final\ClassicShellSrc_%CS_VERSION_STR%.zip *.h *.cpp *.rc *.vcproj *.ini *.def *.ico *.idl *.rgs *.jpg *.manifest *.wxl *.wxs *.sln *.bat *.bmp *.txt *.html *.rtf *.gif *.png *.hhp *.hhc ??-??.dll
+7z a -r -x!*.intermediate.manifest -x!*.embed.manifest -x!*_i.h -x!Website\ ClassicShellSetup\Final\ClassicShellSrc_%CS_VERSION_STR%.zip *.h *.cpp *.rc *.vcproj *.ini *.def *.ico *.idl *.rgs *.jpg *.manifest *.wxl *.wxs *.sln *.bat *.bmp *.txt *.html *.rtf *.gif *.png *.hhp *.hhc ??-??.dll
 
 REM ***** Collect Localization files
 
 del ClassicShellSetup\Final\ClassicShellLoc.zip
-"C:\Program Files\WinRAR\winrar" a -afzip -ep1 -ed -r -x*WixUI_en-us.wxl -x*.adml -x*.admx -x*LocComments.txt ClassicShellSetup\Final\ClassicShellLoc.zip Localization\English ClassicExplorer\ExplorerL10N.ini ClassicStartMenu\StartMenuL10N.ini ClassicStartMenu\StartMenuHelper\StartMenuHelperL10N.ini Localization\English\ClassicShellText-en-US.wxl Localization\English\ClassicShellEULA.rtf
+cd Localization
+7z a -r -x!en-US -x!*WixUI_en-us.wxl -x!*.adml -x!*.admx -x!*LocComments.txt ..\ClassicShellSetup\Final\ClassicShellLoc.zip English ..\ClassicExplorer\ExplorerL10N.ini ..\ClassicStartMenu\StartMenuL10N.ini ..\ClassicStartMenu\StartMenuHelper\StartMenuHelperL10N.ini English\ClassicShellText-en-US.wxl English\ClassicShellEULA.rtf
+cd ..
 
 cd ClassicShellSetup

--- a/ClassicShellSrc/ClassicShellSetup/BuildBinaries.bat
+++ b/ClassicShellSrc/ClassicShellSetup/BuildBinaries.bat
@@ -1,5 +1,3 @@
-@SET CS_ERROR=0
-
 md Output
 del /Q /S Output\*.*
 md Output\x64
@@ -9,19 +7,18 @@ md Output\PDB64
 for /f "usebackq tokens=*" %%i in (`"%ProgramFiles(x86)%\Microsoft Visual Studio\Installer\vswhere.exe" -latest -products * -requires Microsoft.Component.MSBuild -property installationPath`) do set MSBuildDir=%%i\MSBuild\15.0\Bin\
 
 REM ********* Build 64-bit solution
-"%MSBuildDir%MSBuild.exe" ..\ClassicShell.sln /m /t:Rebuild /p:Configuration="Setup" /p:Platform="x64"
-@if ERRORLEVEL 1 goto end
-
+"%MSBuildDir%MSBuild.exe" ..\ClassicShell.sln /m /t:Rebuild /p:Configuration="Setup" /p:Platform="x64" /verbosity:minimal
+@if ERRORLEVEL 1 exit /b 1
 
 REM ********* Build 32-bit solution (must be after 64-bit)
-"%MSBuildDir%MSBuild.exe" ..\ClassicShell.sln /m /t:Rebuild /p:Configuration="Setup" /p:Platform="Win32"
-@if ERRORLEVEL 1 goto end
+"%MSBuildDir%MSBuild.exe" ..\ClassicShell.sln /m /t:Rebuild /p:Configuration="Setup" /p:Platform="Win32" /verbosity:minimal
+@if ERRORLEVEL 1 exit /b 1
 
 
 REM ********* Make en-US.dll
 cd ..
 start /wait ClassicShellSetup\ClassicShellUtility\Release\ClassicShellUtility.exe makeEN ClassicExplorer\Setup\ClassicExplorer32.dll ClassicStartMenu\Setup\ClassicStartMenuDLL.dll ClassicIE\Setup\ClassicIEDLL_32.dll ClassicShellUpdate\Release\ClassicShellUpdate.exe
-@if ERRORLEVEL 1 goto end
+@if ERRORLEVEL 1 exit /b 1
 
 start /wait ClassicShellSetup\ClassicShellUtility\Release\ClassicShellUtility.exe extract en-US.dll en-US.csv
 copy en-US.dll Localization\English
@@ -112,19 +109,15 @@ REM ********* Build ADMX
 del Output\PolicyDefinitions.zip
 cd ..\Localization\English
 ..\..\ClassicStartMenu\Setup\ClassicStartMenu.exe -saveadmx en-US
-@if ERRORLEVEL 1 goto end
+@if ERRORLEVEL 1 exit /b 1
 ..\..\ClassicExplorer\Setup\ClassicExplorerSettings.exe -saveadmx en-US
-@if ERRORLEVEL 1 goto end
+@if ERRORLEVEL 1 exit /b 1
 ..\..\ClassicIE\Setup\ClassicIE_32.exe -saveadmx en-US
-@if ERRORLEVEL 1 goto end
+@if ERRORLEVEL 1 exit /b 1
 md en-US
 copy /B *.adml en-US
 7z a ..\..\ClassicShellSetup\Output\PolicyDefinitions.zip *.admx en-US\*.adml PolicyDefinitions.rtf
 rd /Q /S en-US
 cd ..\..\ClassicShellSetup
 
-
-@goto EOF
-:end
-@SET CS_ERROR=1
-:EOF
+exit /b 0

--- a/ClassicShellSrc/ClassicShellSetup/BuildBinaries.bat
+++ b/ClassicShellSrc/ClassicShellSetup/BuildBinaries.bat
@@ -125,5 +125,4 @@ cd ..\..\ClassicShellSetup
 @goto EOF
 :end
 @SET CS_ERROR=1
-pause
 :EOF

--- a/ClassicShellSrc/ClassicShellSetup/BuildBinaries.bat
+++ b/ClassicShellSrc/ClassicShellSetup/BuildBinaries.bat
@@ -117,8 +117,10 @@ cd ..\Localization\English
 @if ERRORLEVEL 1 goto end
 ..\..\ClassicIE\Setup\ClassicIE_32.exe -saveadmx en-US
 @if ERRORLEVEL 1 goto end
-"C:\Program Files\WinRAR\winrar" a -afzip -ep ..\..\ClassicShellSetup\Output\PolicyDefinitions.zip *.admx PolicyDefinitions.rtf
-"C:\Program Files\WinRAR\winrar" a -afzip -ep -apen-US ..\..\ClassicShellSetup\Output\PolicyDefinitions.zip *.adml
+md en-US
+copy /B *.adml en-US
+7z a ..\..\ClassicShellSetup\Output\PolicyDefinitions.zip *.admx en-US\*.adml PolicyDefinitions.rtf
+rd /Q /S en-US
 cd ..\..\ClassicShellSetup
 
 

--- a/ClassicShellSrc/ClassicShellSetup/BuildBinaries.bat
+++ b/ClassicShellSrc/ClassicShellSetup/BuildBinaries.bat
@@ -9,12 +9,12 @@ md Output\PDB64
 for /f "usebackq tokens=*" %%i in (`"%ProgramFiles(x86)%\Microsoft Visual Studio\Installer\vswhere.exe" -latest -products * -requires Microsoft.Component.MSBuild -property installationPath`) do set MSBuildDir=%%i\MSBuild\15.0\Bin\
 
 REM ********* Build 64-bit solution
-"%MSBuildDir%MSBuild.exe" ..\ClassicShell.sln /t:Rebuild /p:Configuration="Setup" /p:Platform="x64"
+"%MSBuildDir%MSBuild.exe" ..\ClassicShell.sln /m /t:Rebuild /p:Configuration="Setup" /p:Platform="x64"
 @if ERRORLEVEL 1 goto end
 
 
 REM ********* Build 32-bit solution (must be after 64-bit)
-"%MSBuildDir%MSBuild.exe" ..\ClassicShell.sln /t:Rebuild /p:Configuration="Setup" /p:Platform="Win32"
+"%MSBuildDir%MSBuild.exe" ..\ClassicShell.sln /m /t:Rebuild /p:Configuration="Setup" /p:Platform="Win32"
 @if ERRORLEVEL 1 goto end
 
 

--- a/ClassicShellSrc/ClassicShellSetup/BuildInstaller.bat
+++ b/ClassicShellSrc/ClassicShellSetup/BuildInstaller.bat
@@ -79,7 +79,6 @@ copy /B Final\%CS_INSTALLER_NAME%.exe Output\Releases\%CS_INSTALLER_NAME%.exe
 @goto EOF
 :end
 @SET CS_ERROR=1
-pause
 :EOF
 SET CS_LANG_FOLDER=
 SET CS_LANG_NAME=

--- a/ClassicShellSrc/ClassicShellSetup/BuildInstaller.bat
+++ b/ClassicShellSrc/ClassicShellSetup/BuildInstaller.bat
@@ -5,17 +5,18 @@ SET CS_VERSION_NUM=40301
 SET CS_GUID32=8A99142D-5D6E-40b6-AF88-8BD46F0C5CB4
 SET CS_GUID64=CABCE573-0A86-42fa-A52A-C7EA61D5BE08
 
-SET CS_ERROR=0
-
 REM ********* Build Help
+@setlocal EnableDelayedExpansion
 @if %CS_HAS_HELP%==1 (
+	SET CS_ERROR=0
 	if NOT %CS_LANG_FOLDER%==English mklink /J ..\Localization\%CS_LANG_FOLDER%\images ..\Localization\English\images
 	hhc ..\Localization\%CS_LANG_FOLDER%\ClassicShell.hhp
 	@REM looks like hhc returns 0 for error, >0 for success
 	@if NOT ERRORLEVEL 1 @SET CS_ERROR=1
 	if NOT %CS_LANG_FOLDER%==English rmdir ..\Localization\%CS_LANG_FOLDER%\images
-	@if %CS_ERROR%==1 goto end
+	@if !CS_ERROR!==1 exit /b 1
 )
+@endlocal
 @if %CS_HAS_HELP%==0 (
 	copy /Y ..\Localization\English\ClassicShell.chm ..\Localization\%CS_LANG_FOLDER%\ClassicShell.chm
 )
@@ -24,7 +25,7 @@ REM ********* Build Help
 @if %CS_HAS_README%==0 copy /Y ..\Localization\English\ClassicShellReadme.rtf ..\Localization\%CS_LANG_FOLDER%
 
 @if _%CS_LANG_NAME%==_ echo Unrecognized language '%CS_LANG_FOLDER%'
-@if _%CS_LANG_NAME%==_ goto end
+@if _%CS_LANG_NAME%==_ exit /b 1
 
 SET CS_INSTALLER_NAME=ClassicShellSetup_%CS_VERSION_STR%-%CS_LANG_NAME_SHORT%
 if %CS_LANG_NAME_SHORT%==en SET CS_INSTALLER_NAME=ClassicShellSetup_%CS_VERSION_STR%
@@ -32,37 +33,37 @@ if %CS_LANG_NAME_SHORT%==en SET CS_INSTALLER_NAME=ClassicShellSetup_%CS_VERSION_
 md Temp
 del /Q Temp\*.*
 
-@if not exist ..\Localization\%CS_LANG_FOLDER%\ClassicShellText-%CS_LANG_NAME%.wxl goto end
+@if not exist ..\Localization\%CS_LANG_FOLDER%\ClassicShellText-%CS_LANG_NAME%.wxl exit /b 1
 
 REM ********* Build 32-bit MSI
 candle ClassicShellSetup.wxs -out Temp\ClassicShellSetup32.wixobj -ext WixUIExtension -ext WixUtilExtension -dx64=0 -dCS_LANG_FOLDER=%CS_LANG_FOLDER% -dCS_LANG_NAME=%CS_LANG_NAME%
-@if ERRORLEVEL 1 goto end
+@if ERRORLEVEL 1 exit /b 1
 
 @REM We need to suppress ICE38 and ICE43 because they apply only to per-user installation. We only support per-machine installs
 @REM We need to suppress ICE09 because the helper DLLs need to go into the system directory (for safety reasons)
 light Temp\ClassicShellSetup32.wixobj -out Temp\ClassicShellSetup32.msi -ext WixUIExtension -ext WixUtilExtension -loc ..\Localization\%CS_LANG_FOLDER%\ClassicShellText-%CS_LANG_NAME%.wxl -loc ..\Localization\%CS_LANG_FOLDER%\WixUI_%CS_LANG_NAME%.wxl -sice:ICE38 -sice:ICE43 -sice:ICE09
-@if ERRORLEVEL 1 goto end
+@if ERRORLEVEL 1 exit /b 1
 
 
 REM ********* Build 64-bit MSI
 candle ClassicShellSetup.wxs -out Temp\ClassicShellSetup64.wixobj -ext WixUIExtension -ext WixUtilExtension -dx64=1 -dCS_LANG_FOLDER=%CS_LANG_FOLDER% -dCS_LANG_NAME=%CS_LANG_NAME%
-@if ERRORLEVEL 1 goto end
+@if ERRORLEVEL 1 exit /b 1
 
 @REM We need to suppress ICE38 and ICE43 because they apply only to per-user installation. We only support per-machine installs
 @REM We need to suppress ICE09 because the helper DLLs need to go into the system directory (for safety reasons)
 light Temp\ClassicShellSetup64.wixobj -out Temp\ClassicShellSetup64.msi -ext WixUIExtension -ext WixUtilExtension -loc ..\Localization\%CS_LANG_FOLDER%\ClassicShellText-%CS_LANG_NAME%.wxl -loc ..\Localization\%CS_LANG_FOLDER%\WixUI_%CS_LANG_NAME%.wxl -sice:ICE38 -sice:ICE43 -sice:ICE09
-@if ERRORLEVEL 1 goto end
+@if ERRORLEVEL 1 exit /b 1
 
 
 REM ********* Build MSI Checksums
 start /wait ClassicShellUtility\Release\ClassicShellUtility.exe crcmsi Temp
-@if ERRORLEVEL 1 goto end
+@if ERRORLEVEL 1 exit /b 1
 
 REM ********* Build bootstrapper
 for /f "usebackq tokens=*" %%i in (`"%ProgramFiles(x86)%\Microsoft Visual Studio\Installer\vswhere.exe" -latest -products * -requires Microsoft.Component.MSBuild -property installationPath`) do set MSBuildDir=%%i\MSBuild\15.0\Bin\
 
-"%MSBuildDir%MSBuild.exe" ClassicShellSetup.sln /m /t:Rebuild /p:Configuration="Release" /p:Platform="Win32"
-@if ERRORLEVEL 1 goto end
+"%MSBuildDir%MSBuild.exe" ClassicShellSetup.sln /m /t:Rebuild /p:Configuration="Release" /p:Platform="Win32" /verbosity:minimal
+@if ERRORLEVEL 1 exit /b 1
 
 md Final
 
@@ -73,13 +74,8 @@ md Output\Releases
 copy /B Final\%CS_INSTALLER_NAME%.exe Output\Releases\%CS_INSTALLER_NAME%.exe
 
 
-
-
-
-@goto EOF
-:end
-@SET CS_ERROR=1
-:EOF
 SET CS_LANG_FOLDER=
 SET CS_LANG_NAME=
 SET CS_LANG_NAME_SHORT=
+
+exit /b 0

--- a/ClassicShellSrc/ClassicShellSetup/BuildInstaller.bat
+++ b/ClassicShellSrc/ClassicShellSetup/BuildInstaller.bat
@@ -61,7 +61,7 @@ start /wait ClassicShellUtility\Release\ClassicShellUtility.exe crcmsi Temp
 REM ********* Build bootstrapper
 for /f "usebackq tokens=*" %%i in (`"%ProgramFiles(x86)%\Microsoft Visual Studio\Installer\vswhere.exe" -latest -products * -requires Microsoft.Component.MSBuild -property installationPath`) do set MSBuildDir=%%i\MSBuild\15.0\Bin\
 
-"%MSBuildDir%MSBuild.exe" ClassicShellSetup.sln /t:Rebuild /p:Configuration="Release" /p:Platform="Win32"
+"%MSBuildDir%MSBuild.exe" ClassicShellSetup.sln /m /t:Rebuild /p:Configuration="Release" /p:Platform="Win32"
 @if ERRORLEVEL 1 goto end
 
 md Final

--- a/ClassicShellSrc/ClassicShellSetup/BuildInstaller.bat
+++ b/ClassicShellSrc/ClassicShellSetup/BuildInstaller.bat
@@ -70,6 +70,10 @@ md Final
 del Final\%CS_INSTALLER_NAME%.exe
 copy /B Release\ClassicShellSetup.exe Final\%CS_INSTALLER_NAME%.exe
 
+if defined APPVEYOR (
+	appveyor PushArtifact Release\ClassicShellSetup.exe -FileName %CS_INSTALLER_NAME%.exe
+)
+
 md Output\Releases
 copy /B Final\%CS_INSTALLER_NAME%.exe Output\Releases\%CS_INSTALLER_NAME%.exe
 

--- a/ClassicShellSrc/ClassicShellSetup/__MakeFinal.bat
+++ b/ClassicShellSrc/ClassicShellSetup/__MakeFinal.bat
@@ -1,9 +1,11 @@
+@cd %~dp0
+
 @call BuildBinaries.bat
-@if %CS_ERROR%==1 goto end
+@if ERRORLEVEL 1 exit /b 1
 
 @call _BuildEnglish.bat
-@if %CS_ERROR%==1 goto end
+@if ERRORLEVEL 1 exit /b 1
 
 call BuildArchives.bat
 
-:end
+@exit /b 0

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,0 +1,13 @@
+version: 4.4.{build}
+pull_requests:
+  do_not_increment_build_number: true
+branches:
+  only:
+  - master
+image: Visual Studio 2017
+shallow_clone: true
+install:
+- cmd: set PATH=C:\Program Files (x86)\WiX Toolset v3.11\bin;C:\Program Files (x86)\HTML Help Workshop;%PATH%
+build_script:
+- cmd: ClassicShellSrc\ClassicShellSetup\__MakeFinal.bat
+test: off


### PR DESCRIPTION
With these changes it is possible to build full _ClassicShell_ installer on _Appveyor_.
Here are results of such builds here:
https://ci.appveyor.com/project/ge0rdi/classic-shell

For now it stores just the installer in build artifacts. We can later decide/change what else to store there.

Also for now the version of installer (and binaries inside) is not set according to _Appveyor_ version.
This is something I'd like to improve soon.

Fixes #6.